### PR TITLE
Module

### DIFF
--- a/code/ast/main.fer.json
+++ b/code/ast/main.fer.json
@@ -50,17 +50,94 @@
         }
     },
     {
+        "Variables": [
+            {
+                "Identifier": {
+                    "Name": "x",
+                    "Start": {
+                        "Line": 5,
+                        "Column": 5,
+                        "Index": 38
+                    },
+                    "End": {
+                        "Line": 5,
+                        "Column": 16,
+                        "Index": 39
+                    }
+                },
+                "ExplicitType": null
+            }
+        ],
+        "Initializers": [
+            {
+                "Elements": [
+                    {
+                        "Value": 2,
+                        "Raw": "2",
+                        "Base": 10,
+                        "Start": {
+                            "Line": 5,
+                            "Column": 11,
+                            "Index": 44
+                        },
+                        "End": {
+                            "Line": 5,
+                            "Column": 12,
+                            "Index": 45
+                        }
+                    },
+                    {
+                        "Value": 5,
+                        "Raw": "5",
+                        "Base": 10,
+                        "Start": {
+                            "Line": 5,
+                            "Column": 13,
+                            "Index": 46
+                        },
+                        "End": {
+                            "Line": 5,
+                            "Column": 14,
+                            "Index": 47
+                        }
+                    }
+                ],
+                "Start": {
+                    "Line": 5,
+                    "Column": 9,
+                    "Index": 42
+                },
+                "End": {
+                    "Line": 5,
+                    "Column": 15,
+                    "Index": 48
+                }
+            }
+        ],
+        "IsConst": false,
+        "Start": {
+            "Line": 5,
+            "Column": 1,
+            "Index": 34
+        },
+        "End": {
+            "Line": 5,
+            "Column": 16,
+            "Index": 39
+        }
+    },
+    {
         "Identifier": {
             "Name": "main",
             "Start": {
-                "Line": 5,
+                "Line": 7,
                 "Column": 4,
-                "Index": 37
+                "Index": 56
             },
             "End": {
-                "Line": 5,
+                "Line": 7,
                 "Column": 8,
-                "Index": 41
+                "Index": 60
             }
         },
         "Function": {
@@ -75,112 +152,112 @@
                                     "Module": {
                                         "Name": "fmt",
                                         "Start": {
-                                            "Line": 6,
+                                            "Line": 8,
                                             "Column": 5,
-                                            "Index": 51
+                                            "Index": 70
                                         },
                                         "End": {
-                                            "Line": 6,
+                                            "Line": 8,
                                             "Column": 8,
-                                            "Index": 54
+                                            "Index": 73
                                         }
                                     },
-                                    "Member": {
+                                    "Identifier": {
                                         "Name": "Println",
                                         "Start": {
-                                            "Line": 6,
+                                            "Line": 8,
                                             "Column": 10,
-                                            "Index": 56
+                                            "Index": 75
                                         },
                                         "End": {
-                                            "Line": 6,
+                                            "Line": 8,
                                             "Column": 17,
-                                            "Index": 63
+                                            "Index": 82
                                         }
                                     },
                                     "Start": {
-                                        "Line": 6,
+                                        "Line": 8,
                                         "Column": 5,
-                                        "Index": 51
+                                        "Index": 70
                                     },
                                     "End": {
-                                        "Line": 6,
+                                        "Line": 8,
                                         "Column": 17,
-                                        "Index": 63
+                                        "Index": 82
                                     }
                                 },
                                 "Arguments": [
                                     {
                                         "Value": "Hello, Ferret!",
                                         "Start": {
-                                            "Line": 6,
+                                            "Line": 8,
                                             "Column": 18,
-                                            "Index": 64
+                                            "Index": 83
                                         },
                                         "End": {
-                                            "Line": 6,
+                                            "Line": 8,
                                             "Column": 34,
-                                            "Index": 80
+                                            "Index": 99
                                         }
                                     }
                                 ],
                                 "Start": {
-                                    "Line": 6,
+                                    "Line": 8,
                                     "Column": 5,
-                                    "Index": 51
+                                    "Index": 70
                                 },
                                 "End": {
-                                    "Line": 6,
+                                    "Line": 8,
                                     "Column": 36,
-                                    "Index": 81
+                                    "Index": 100
                                 }
                             }
                         ],
                         "Location": {
                             "Start": {
-                                "Line": 6,
+                                "Line": 8,
                                 "Column": 5,
-                                "Index": 51
+                                "Index": 70
                             },
                             "End": {
-                                "Line": 6,
+                                "Line": 8,
                                 "Column": 36,
-                                "Index": 81
+                                "Index": 100
                             }
                         }
                     }
                 ],
                 "Start": {
-                    "Line": 5,
+                    "Line": 7,
                     "Column": 11,
-                    "Index": 44
+                    "Index": 63
                 },
                 "End": {
-                    "Line": 7,
+                    "Line": 9,
                     "Column": 2,
-                    "Index": 85
+                    "Index": 104
                 }
             },
             "Start": {
-                "Line": 5,
+                "Line": 7,
                 "Column": 1,
-                "Index": 34
+                "Index": 53
             },
             "End": {
-                "Line": 7,
+                "Line": 9,
                 "Column": 2,
-                "Index": 85
+                "Index": 104
             }
         },
         "Start": {
-            "Line": 5,
+            "Line": 7,
             "Column": 1,
-            "Index": 34
+            "Index": 53
         },
         "End": {
-            "Line": 7,
+            "Line": 9,
             "Column": 2,
-            "Index": 85
+            "Index": 104
         }
     }
 ]

--- a/code/ast/main.fer.json
+++ b/code/ast/main.fer.json
@@ -1,0 +1,104 @@
+[
+    {
+        "Package": {
+            "Name": "main",
+            "Start": {
+                "Line": 1,
+                "Column": 9,
+                "Index": 8
+            },
+            "End": {
+                "Line": 1,
+                "Column": 14,
+                "Index": 12
+            }
+        },
+        "Start": {
+            "Line": 1,
+            "Column": 1,
+            "Index": 0
+        },
+        "End": {
+            "Line": 1,
+            "Column": 14,
+            "Index": 12
+        }
+    },
+    {
+        "Import": {
+            "Value": "fmt",
+            "Start": {
+                "Line": 3,
+                "Column": 8,
+                "Index": 24
+            },
+            "End": {
+                "Line": 3,
+                "Column": 14,
+                "Index": 29
+            }
+        },
+        "Start": {
+            "Line": 3,
+            "Column": 1,
+            "Index": 17
+        },
+        "End": {
+            "Line": 3,
+            "Column": 14,
+            "Index": 29
+        }
+    },
+    {
+        "Identifier": {
+            "Name": "main",
+            "Start": {
+                "Line": 5,
+                "Column": 4,
+                "Index": 37
+            },
+            "End": {
+                "Line": 5,
+                "Column": 8,
+                "Index": 41
+            }
+        },
+        "Function": {
+            "Params": [],
+            "ReturnType": null,
+            "Body": {
+                "Nodes": [],
+                "Start": {
+                    "Line": 5,
+                    "Column": 11,
+                    "Index": 44
+                },
+                "End": {
+                    "Line": 7,
+                    "Column": 2,
+                    "Index": 87
+                }
+            },
+            "Start": {
+                "Line": 5,
+                "Column": 1,
+                "Index": 34
+            },
+            "End": {
+                "Line": 7,
+                "Column": 2,
+                "Index": 87
+            }
+        },
+        "Start": {
+            "Line": 5,
+            "Column": 1,
+            "Index": 34
+        },
+        "End": {
+            "Line": 7,
+            "Column": 2,
+            "Index": 87
+        }
+    }
+]

--- a/code/ast/main.fer.json
+++ b/code/ast/main.fer.json
@@ -67,7 +67,89 @@
             "Params": [],
             "ReturnType": null,
             "Body": {
-                "Nodes": [],
+                "Nodes": [
+                    {
+                        "Expressions": [
+                            {
+                                "Caller": {
+                                    "Module": {
+                                        "Name": "fmt",
+                                        "Start": {
+                                            "Line": 6,
+                                            "Column": 5,
+                                            "Index": 51
+                                        },
+                                        "End": {
+                                            "Line": 6,
+                                            "Column": 8,
+                                            "Index": 54
+                                        }
+                                    },
+                                    "Member": {
+                                        "Name": "Println",
+                                        "Start": {
+                                            "Line": 6,
+                                            "Column": 10,
+                                            "Index": 56
+                                        },
+                                        "End": {
+                                            "Line": 6,
+                                            "Column": 17,
+                                            "Index": 63
+                                        }
+                                    },
+                                    "Start": {
+                                        "Line": 6,
+                                        "Column": 5,
+                                        "Index": 51
+                                    },
+                                    "End": {
+                                        "Line": 6,
+                                        "Column": 17,
+                                        "Index": 63
+                                    }
+                                },
+                                "Arguments": [
+                                    {
+                                        "Value": "Hello, Ferret!",
+                                        "Start": {
+                                            "Line": 6,
+                                            "Column": 18,
+                                            "Index": 64
+                                        },
+                                        "End": {
+                                            "Line": 6,
+                                            "Column": 34,
+                                            "Index": 80
+                                        }
+                                    }
+                                ],
+                                "Start": {
+                                    "Line": 6,
+                                    "Column": 5,
+                                    "Index": 51
+                                },
+                                "End": {
+                                    "Line": 6,
+                                    "Column": 36,
+                                    "Index": 81
+                                }
+                            }
+                        ],
+                        "Location": {
+                            "Start": {
+                                "Line": 6,
+                                "Column": 5,
+                                "Index": 51
+                            },
+                            "End": {
+                                "Line": 6,
+                                "Column": 36,
+                                "Index": 81
+                            }
+                        }
+                    }
+                ],
                 "Start": {
                     "Line": 5,
                     "Column": 11,
@@ -76,7 +158,7 @@
                 "End": {
                     "Line": 7,
                     "Column": 2,
-                    "Index": 87
+                    "Index": 85
                 }
             },
             "Start": {
@@ -87,7 +169,7 @@
             "End": {
                 "Line": 7,
                 "Column": 2,
-                "Index": 87
+                "Index": 85
             }
         },
         "Start": {
@@ -98,7 +180,7 @@
         "End": {
             "Line": 7,
             "Column": 2,
-            "Index": 87
+            "Index": 85
         }
     }
 ]

--- a/code/main.fer
+++ b/code/main.fer
@@ -1,0 +1,8 @@
+package main;
+
+import "fmt";
+
+fn main() {
+    import "os";
+    //fmt::Println("Hello, Ferret!");
+}

--- a/code/main.fer
+++ b/code/main.fer
@@ -3,6 +3,5 @@ package main;
 import "fmt";
 
 fn main() {
-    import "os";
-    //fmt::Println("Hello, Ferret!");
+    fmt::Println("Hello, Ferret!");
 }

--- a/code/main.fer
+++ b/code/main.fer
@@ -2,6 +2,8 @@ package main;
 
 import "fmt";
 
+let x = [2, 5];
+
 fn main() {
     fmt::Println("Hello, Ferret!");
 }

--- a/compiler/internal/ast/expr.go
+++ b/compiler/internal/ast/expr.go
@@ -118,3 +118,15 @@ func (f *FieldAccessExpr) Expr()                     {} // Expr is a marker inte
 func (f *FieldAccessExpr) LValue()                   {} // LValue is a marker interface for all lvalues
 func (f *FieldAccessExpr) StartPos() *lexer.Position { return f.Start }
 func (f *FieldAccessExpr) EndPos() *lexer.Position   { return f.End }
+
+// ScopeResolutionExpr represents a scope resolution expression like fmt::Println
+type ScopeResolutionExpr struct {
+	Module     *IdentifierExpr
+	Identifier *IdentifierExpr
+	Location
+}
+
+func (s *ScopeResolutionExpr) INode()                    {} // INode is a marker interface for all nodes
+func (s *ScopeResolutionExpr) Expr()                     {} // Expr is a marker interface for all expressions
+func (s *ScopeResolutionExpr) StartPos() *lexer.Position { return s.Start }
+func (s *ScopeResolutionExpr) EndPos() *lexer.Position   { return s.End }

--- a/compiler/internal/ast/stmt.go
+++ b/compiler/internal/ast/stmt.go
@@ -53,3 +53,25 @@ func (r *ReturnStmt) INode()                    {} // INode is a marker interfac
 func (r *ReturnStmt) Stmt()                     {} // Stmt is a marker method for statements
 func (r *ReturnStmt) StartPos() *lexer.Position { return r.Start }
 func (r *ReturnStmt) EndPos() *lexer.Position   { return r.End }
+
+// PackageDeclStmt represents a package declaration
+type PackageDeclStmt struct {
+	Package *IdentifierExpr
+	Location
+}
+
+func (p *PackageDeclStmt) INode()                    {} // INode is a marker interface for all nodes
+func (p *PackageDeclStmt) Stmt()                     {} // Stmt is a marker interface for all statements
+func (p *PackageDeclStmt) StartPos() *lexer.Position { return p.Start }
+func (p *PackageDeclStmt) EndPos() *lexer.Position   { return p.End }
+
+// ImportStmt represents an import statement
+type ImportStmt struct {
+	Import *StringLiteral
+	Location
+}
+
+func (i *ImportStmt) INode()                    {} // INode is a marker interface for all nodes
+func (i *ImportStmt) Stmt()                     {} // Stmt is a marker interface for all statements
+func (i *ImportStmt) StartPos() *lexer.Position { return i.Start }
+func (i *ImportStmt) EndPos() *lexer.Position   { return i.End }

--- a/compiler/internal/lexer/tokenizer.go
+++ b/compiler/internal/lexer/tokenizer.go
@@ -72,6 +72,7 @@ func createLexer(filePath *string) *Lexer {
 			{regexp.MustCompile(`\-\-`), defaultHandler(MINUS_MINUS_TOKEN)},
 			{regexp.MustCompile(`\->`), defaultHandler(ARROW_TOKEN)},
 			{regexp.MustCompile(`\=>`), defaultHandler(FAT_ARROW_TOKEN)},
+			{regexp.MustCompile(`::`), defaultHandler(SCOPE_TOKEN)}, // Add scope resolution operator before single colon
 			{regexp.MustCompile(`!=`), defaultHandler(NOT_EQUAL_TOKEN)},
 			{regexp.MustCompile(`\+=`), defaultHandler(PLUS_EQUALS_TOKEN)},
 			{regexp.MustCompile(`-=`), defaultHandler(MINUS_EQUALS_TOKEN)},

--- a/compiler/internal/lexer/tokens.go
+++ b/compiler/internal/lexer/tokens.go
@@ -23,6 +23,8 @@ const (
 	IDENTIFIER_TOKEN TOKEN = "identifier"
 	PRIVATE_TOKEN    TOKEN = "priv"
 	RETURN_TOKEN     TOKEN = "return"
+	IMPORT_TOKEN     TOKEN = "import"
+	PACKAGE_TOKEN    TOKEN = "package"
 	//data types
 	NUMBER_TOKEN    TOKEN = "numeric literal"
 	STRING_TOKEN    TOKEN = "string literal"
@@ -60,6 +62,7 @@ const (
 	LESS_TOKEN          TOKEN = "<"
 	GREATER_TOKEN       TOKEN = ">"
 	//assignment
+	SCOPE_TOKEN        TOKEN = "::"
 	COLON_TOKEN        TOKEN = ":"
 	EQUALS_TOKEN       TOKEN = "="
 	PLUS_EQUALS_TOKEN  TOKEN = "+="
@@ -101,6 +104,8 @@ var keyWordsMap map[TOKEN]bool = map[TOKEN]bool{
 	INTERFACE_TOKEN: true,
 	FUNCTION_TOKEN:  true,
 	RETURN_TOKEN:    true,
+	IMPORT_TOKEN:    true,
+	PACKAGE_TOKEN:   true,
 }
 
 func IsKeyword(token string) bool {

--- a/compiler/internal/parser/expr.go
+++ b/compiler/internal/parser/expr.go
@@ -194,14 +194,14 @@ func parseUnary(p *Parser) ast.Expression {
 }
 
 // parseIndexing handles array/map indexing operations
-func parseIndexing(p *Parser, expr ast.Expression) ast.Expression {
+func parseIndexing(p *Parser, expr ast.Expression) (ast.Expression, bool) {
 	start := expr.StartPos()
 	p.advance() // consume '['
 
 	index := parseExpression(p)
 	if index == nil {
 		report.Add(p.filePath, p.peek().Start.Line, p.peek().End.Line, p.peek().Start.Column, p.peek().End.Column, report.MISSING_INDEX_EXPRESSION).SetLevel(report.SYNTAX_ERROR)
-		return nil
+		return nil, false
 	}
 
 	end := p.consume(lexer.CLOSE_BRACKET, report.EXPECTED_CLOSE_BRACKET)
@@ -212,11 +212,11 @@ func parseIndexing(p *Parser, expr ast.Expression) ast.Expression {
 			Start: start,
 			End:   &end.End,
 		},
-	}
+	}, true
 }
 
 // parseIncDec handles postfix increment/decrement
-func parseIncDec(p *Parser, expr ast.Expression) ast.Expression {
+func parseIncDec(p *Parser, expr ast.Expression) (ast.Expression, bool) {
 	operator := p.advance()
 	if p.match(lexer.PLUS_PLUS_TOKEN, lexer.MINUS_MINUS_TOKEN) {
 		errMsg := report.INVALID_CONSECUTIVE_INCREMENT
@@ -224,7 +224,7 @@ func parseIncDec(p *Parser, expr ast.Expression) ast.Expression {
 			errMsg = report.INVALID_CONSECUTIVE_DECREMENT
 		}
 		report.Add(p.filePath, operator.Start.Line, operator.End.Line, operator.Start.Column, operator.End.Column, errMsg).SetLevel(report.SYNTAX_ERROR)
-		return nil
+		return nil, false
 	}
 	return &ast.PostfixExpr{
 		Operand:  expr,
@@ -233,7 +233,7 @@ func parseIncDec(p *Parser, expr ast.Expression) ast.Expression {
 			Start: expr.StartPos(),
 			End:   &operator.End,
 		},
-	}
+	}, true
 }
 
 // handlePostfixOperator handles a single postfix operator and returns the updated expression
@@ -244,19 +244,23 @@ func handlePostfixOperator(p *Parser, expr ast.Expression) (ast.Expression, bool
 			report.Add(p.filePath, current.Start.Line, current.End.Line, current.Start.Column, current.End.Column, "Cannot mix prefix and postfix operators").SetLevel(report.SYNTAX_ERROR)
 			return nil, false
 		}
-		return parseIncDec(p, expr), true
+		return parseIncDec(p, expr)
 	}
 
 	if p.match(lexer.DOT_TOKEN) {
-		return parseFieldAccess(p, expr), true
+		return parseFieldAccess(p, expr)
+	}
+
+	if p.match(lexer.SCOPE_TOKEN) {
+		return parseScopeResolution(p, expr)
 	}
 
 	if p.match(lexer.OPEN_PAREN) {
-		return parseFunctionCall(p, expr), true
+		return parseFunctionCall(p, expr)
 	}
 
 	if p.match(lexer.OPEN_BRACKET) {
-		return parseIndexing(p, expr), true
+		return parseIndexing(p, expr)
 	}
 
 	return nil, false
@@ -292,44 +296,35 @@ func parseGrouping(p *Parser) ast.Expression {
 }
 
 // parseFunctionCall parses a function call expression
-func parseFunctionCall(p *Parser, caller ast.Expression) ast.Expression {
+func parseFunctionCall(p *Parser, caller ast.Expression) (ast.Expression, bool) {
 	start := caller.StartPos()
 	p.advance() // consume '('
 
 	arguments := make([]ast.Expression, 0)
-
-	// Handle empty argument list
-	if p.peek().Kind == lexer.CLOSE_PAREN {
-		end := p.advance() // consume ')'
-		return &ast.FunctionCallExpr{
-			Caller:    caller,
-			Arguments: arguments,
-			Location: ast.Location{
-				Start: start,
-				End:   &end.End,
-			},
-		}
-	}
-
 	// Parse arguments
-	for {
+	for !p.match(lexer.CLOSE_PAREN) {
 		arg := parseExpression(p)
 		if arg == nil {
 			report.Add(p.filePath, p.peek().Start.Line, p.peek().End.Line,
 				p.peek().Start.Column, p.peek().End.Column,
 				"Expected function argument").SetLevel(report.SYNTAX_ERROR)
-			return nil
+			return nil, false
 		}
 		arguments = append(arguments, arg)
 
 		if p.match(lexer.CLOSE_PAREN) {
 			break
 		} else {
-			p.consume(lexer.COMMA_TOKEN, report.EXPECTED_COMMA_OR_CLOSE_PAREN)
+			comma := p.consume(lexer.COMMA_TOKEN, report.EXPECTED_COMMA_OR_CLOSE_PAREN)
+			if p.match(lexer.CLOSE_PAREN) {
+				report.Add(p.filePath, comma.Start.Line, comma.End.Line, comma.Start.Column, comma.End.Column, report.TRAILING_COMMA_NOT_ALLOWED).AddHint("Remove the trailing comma").SetLevel(report.WARNING)
+				break
+			}
 		}
 	}
 
 	end := p.consume(lexer.CLOSE_PAREN, report.EXPECTED_CLOSE_PAREN)
+
 	return &ast.FunctionCallExpr{
 		Caller:    caller,
 		Arguments: arguments,
@@ -337,7 +332,7 @@ func parseFunctionCall(p *Parser, caller ast.Expression) ast.Expression {
 			Start: start,
 			End:   &end.End,
 		},
-	}
+	}, true
 }
 
 // parsePrimary handles literals, identifiers, and parenthesized expressions

--- a/compiler/internal/parser/function.go
+++ b/compiler/internal/parser/function.go
@@ -115,7 +115,7 @@ func parseParameters(p *Parser) []ast.Parameter {
 		} else {
 			comma := p.consume(lexer.COMMA_TOKEN, report.EXPECTED_COMMA_OR_CLOSE_PAREN)
 			if p.match(lexer.CLOSE_PAREN) {
-				report.Add(p.filePath, comma.Start.Line, comma.End.Line, comma.Start.Column, comma.End.Column, report.TRAILING_COMMA_NOT_ALLOWED).AddHint("Remove the trailing comma").SetLevel(report.SYNTAX_ERROR)
+				report.Add(p.filePath, comma.Start.Line, comma.End.Line, comma.Start.Column, comma.End.Column, report.TRAILING_COMMA_NOT_ALLOWED).AddHint("Remove the trailing comma").SetLevel(report.WARNING)
 				break
 			}
 		}
@@ -154,7 +154,7 @@ func parseReturnTypes(p *Parser) []ast.DataType {
 
 		if p.match(lexer.CLOSE_PAREN) {
 			break
-		} else if p.match(lexer.COMMA_TOKEN) && p.next().Kind != lexer.CLOSE_PAREN {
+		} else {
 			comma := p.consume(lexer.COMMA_TOKEN, report.EXPECTED_COMMA_OR_CLOSE_PAREN)
 			if p.match(lexer.CLOSE_PAREN) {
 				report.Add(p.filePath, comma.Start.Line, comma.End.Line, comma.Start.Column, comma.End.Column, report.TRAILING_COMMA_NOT_ALLOWED).AddHint("Remove the trailing comma").SetLevel(report.WARNING)

--- a/compiler/internal/parser/function.go
+++ b/compiler/internal/parser/function.go
@@ -129,33 +129,7 @@ func parseParameters(p *Parser) []ast.Parameter {
 func parseReturnTypes(p *Parser) []ast.DataType {
 	p.advance()
 	// Check for multiple return types in parentheses
-	if p.peek().Kind == lexer.OPEN_PAREN {
-		p.advance() // consume '('
-		returnTypes := make([]ast.DataType, 0)
-
-		for !p.match(lexer.CLOSE_PAREN) {
-			returnType, ok := parseType(p)
-			if !ok {
-				token := p.previous()
-				report.Add(p.filePath, token.Start.Line, token.End.Line, token.Start.Column, token.End.Column, report.EXPECTED_RETURN_TYPE).AddHint("Add a return type after the arrow").SetLevel(report.SYNTAX_ERROR)
-				return nil
-			}
-			returnTypes = append(returnTypes, returnType)
-
-			if p.match(lexer.CLOSE_PAREN) {
-				break
-			} else if p.match(lexer.COMMA_TOKEN) && p.next().Kind != lexer.CLOSE_PAREN {
-				p.consume(lexer.COMMA_TOKEN, report.EXPECTED_COMMA_OR_CLOSE_PAREN)
-			} else {
-				token := p.peek()
-				report.Add(p.filePath, token.Start.Line, token.End.Line, token.Start.Column, token.End.Column, report.EXPECTED_COMMA_OR_CLOSE_PAREN).AddHint("Add a comma after the return type").SetLevel(report.SYNTAX_ERROR)
-				return nil
-			}
-		}
-
-		p.consume(lexer.CLOSE_PAREN, report.EXPECTED_CLOSE_PAREN)
-		return returnTypes
-	} else {
+	if p.peek().Kind != lexer.OPEN_PAREN {
 		// Single return type
 		returnType, ok := parseType(p)
 		if !ok {
@@ -165,6 +139,32 @@ func parseReturnTypes(p *Parser) []ast.DataType {
 		}
 		return []ast.DataType{returnType}
 	}
+
+	p.advance() // consume '('
+	returnTypes := make([]ast.DataType, 0)
+
+	for !p.match(lexer.CLOSE_PAREN) {
+		returnType, ok := parseType(p)
+		if !ok {
+			token := p.previous()
+			report.Add(p.filePath, token.Start.Line, token.End.Line, token.Start.Column, token.End.Column, report.EXPECTED_RETURN_TYPE).AddHint("Add a return type after the arrow").SetLevel(report.SYNTAX_ERROR)
+			return nil
+		}
+		returnTypes = append(returnTypes, returnType)
+
+		if p.match(lexer.CLOSE_PAREN) {
+			break
+		} else if p.match(lexer.COMMA_TOKEN) && p.next().Kind != lexer.CLOSE_PAREN {
+			comma := p.consume(lexer.COMMA_TOKEN, report.EXPECTED_COMMA_OR_CLOSE_PAREN)
+			if p.match(lexer.CLOSE_PAREN) {
+				report.Add(p.filePath, comma.Start.Line, comma.End.Line, comma.Start.Column, comma.End.Column, report.TRAILING_COMMA_NOT_ALLOWED).AddHint("Remove the trailing comma").SetLevel(report.WARNING)
+				break
+			}
+		}
+	}
+
+	p.consume(lexer.CLOSE_PAREN, report.EXPECTED_CLOSE_PAREN)
+	return returnTypes
 }
 
 func parseSignature(p *Parser, parseNewParams bool, params ...ast.Parameter) ([]ast.Parameter, []ast.DataType) {

--- a/compiler/internal/parser/function_test.go
+++ b/compiler/internal/parser/function_test.go
@@ -66,8 +66,8 @@ func TestFunctionParsing(t *testing.T) {
 		{
 			name:    "Invalid return type syntax",
 			input:   "fn add(a: i32, b: i32) -> (i32,) { return 0; }",
-			isValid: false,
-			desc:    "Function with trailing comma in return type list should fail",
+			isValid: true,
+			desc:    "Function with trailing comma in return type list should pass with a warning",
 		},
 		{
 			name:    "Missing function body",
@@ -96,14 +96,14 @@ func TestFunctionParsing(t *testing.T) {
 		{
 			name:    "Invalid parameter list",
 			input:   "fn bad(a: i32,) -> i32 { return a; }",
-			isValid: false,
-			desc:    "Function with trailing comma in parameter list should fail",
+			isValid: true,
+			desc:    "Function with trailing comma in parameter list should pass with a warning",
 		},
 		{
 			name:    "Trailing comma in function return type",
 			input:   "fn add(a: i32, b: i32) -> (i32, f32,) { return a + b, 1.0; }",
-			isValid: false,
-			desc:    "Function with trailing comma in return type should fail",
+			isValid: true,
+			desc:    "Function with trailing comma in return type should pass with a warning",
 		},
 		{
 			name:    "Function call with no arguments",
@@ -132,8 +132,8 @@ func TestFunctionParsing(t *testing.T) {
 		{
 			name:    "Function call with trailing comma",
 			input:   "hello(1, 2, 4,);",
-			isValid: false,
-			desc:    "Function call with trailing comma should fail",
+			isValid: true,
+			desc:    "Function call with trailing comma should pass with a warning",
 		},
 	}
 

--- a/compiler/internal/parser/literals.go
+++ b/compiler/internal/parser/literals.go
@@ -120,7 +120,7 @@ func parseArrayLiteral(p *Parser) ast.Expression {
 
 		if p.match(lexer.CLOSE_BRACKET) {
 			break
-		} else if p.match(lexer.COMMA_TOKEN) && p.next().Kind != lexer.CLOSE_BRACKET {
+		} else {
 			comma := p.consume(lexer.COMMA_TOKEN, report.EXPECTED_COMMA_OR_CLOSE_BRACKET)
 			if p.match(lexer.CLOSE_BRACKET) {
 				report.Add(p.filePath, comma.Start.Line, comma.End.Line, comma.Start.Column, comma.End.Column, report.TRAILING_COMMA_NOT_ALLOWED).AddHint("Remove the trailing comma").SetLevel(report.WARNING)

--- a/compiler/internal/parser/literals.go
+++ b/compiler/internal/parser/literals.go
@@ -121,11 +121,11 @@ func parseArrayLiteral(p *Parser) ast.Expression {
 		if p.match(lexer.CLOSE_BRACKET) {
 			break
 		} else if p.match(lexer.COMMA_TOKEN) && p.next().Kind != lexer.CLOSE_BRACKET {
-			p.consume(lexer.COMMA_TOKEN, report.EXPECTED_COMMA_OR_CLOSE_BRACKET)
-		} else {
-			token := p.peek()
-			report.Add(p.filePath, token.Start.Line, token.End.Line, token.Start.Column, token.End.Column, report.EXPECTED_COMMA_OR_CLOSE_BRACKET).AddHint("Add a comma after the element").SetLevel(report.SYNTAX_ERROR)
-			return nil
+			comma := p.consume(lexer.COMMA_TOKEN, report.EXPECTED_COMMA_OR_CLOSE_BRACKET)
+			if p.match(lexer.CLOSE_BRACKET) {
+				report.Add(p.filePath, comma.Start.Line, comma.End.Line, comma.Start.Column, comma.End.Column, report.TRAILING_COMMA_NOT_ALLOWED).AddHint("Remove the trailing comma").SetLevel(report.WARNING)
+				break
+			}
 		}
 	}
 

--- a/compiler/internal/parser/literals_test.go
+++ b/compiler/internal/parser/literals_test.go
@@ -57,7 +57,7 @@ func TestLiteralParsing(t *testing.T) {
 		{"let x = [1, 2;", false, "Unclosed array literal"},
 		{"let x = [,];", false, "Invalid array literal with just comma"},
 		{"let x = [1 2];", false, "Array literal missing comma"},
-		{"let x = [1, 2,];", false, "Array literal with trailing comma"},
+		{"let x = [1, 2,];", true, "Array literal with trailing comma"},
 	}
 
 	for _, tt := range tests {

--- a/compiler/internal/parser/package.go
+++ b/compiler/internal/parser/package.go
@@ -4,7 +4,9 @@ import (
 	"ferret/compiler/internal/ast"
 	"ferret/compiler/internal/lexer"
 	"ferret/compiler/internal/symboltable"
+	"ferret/compiler/internal/types"
 	"ferret/compiler/report"
+	"strings"
 )
 
 // parsePackage parses a package declaration
@@ -43,14 +45,36 @@ func parsePackage(p *Parser) ast.Node {
 
 // parseImport parses an import statement
 func parseImport(p *Parser) ast.Node {
-
 	start := p.consume(lexer.IMPORT_TOKEN, report.EXPECTED_IMPORT_KEYWORD)
-
 	importPath := p.consume(lexer.STRING_TOKEN, report.EXPECTED_IMPORT_PATH)
 
 	// check scope
 	if p.currentScope.ScopeKind() != symboltable.GLOBAL_SCOPE {
 		report.Add(p.filePath, start.Start.Line, importPath.End.Line, start.Start.Column, importPath.End.Column, report.INVALID_SCOPE).AddHint("Import statements must be at the top level of the file").SetLevel(report.SYNTAX_ERROR)
+	}
+
+	// Get module name from import path (last component)
+	moduleName := strings.Trim(importPath.Value, "\"")
+	if lastSlash := strings.LastIndex(moduleName, "/"); lastSlash >= 0 {
+		moduleName = moduleName[lastSlash+1:]
+	}
+
+	// Add module to symbol table
+	sym := &symboltable.Symbol{
+		Name:       moduleName,
+		SymbolKind: symboltable.MODULE_SYMBOL,
+		Type:       types.MODULE,
+		IsExported: true,
+		Module:     moduleName,
+		Location: symboltable.SymbolLocation{
+			File:   p.filePath,
+			Line:   start.Start.Line,
+			Column: start.Start.Column,
+		},
+	}
+
+	if !p.currentScope.Define(sym) {
+		report.Add(p.filePath, start.Start.Line, importPath.End.Line, start.Start.Column, importPath.End.Column, "Module already imported").SetLevel(report.SEMANTIC_ERROR)
 	}
 
 	return &ast.ImportStmt{
@@ -65,5 +89,28 @@ func parseImport(p *Parser) ast.Node {
 			Start: &start.Start,
 			End:   &importPath.End,
 		},
+	}
+}
+
+func parseScopeResolution(p *Parser, expr ast.Expression) (ast.Expression, bool) {
+	// Handle scope resolution operator
+	if module, ok := expr.(*ast.IdentifierExpr); ok {
+		p.consume(lexer.SCOPE_TOKEN, report.EXPECTED_SCOPE_RESOLUTION_OPERATOR)
+		if !p.match(lexer.IDENTIFIER_TOKEN) {
+			report.Add(p.filePath, p.peek().Start.Line, p.peek().End.Line, p.peek().Start.Column, p.peek().End.Column, "Expected identifier after '::'").SetLevel(report.SYNTAX_ERROR)
+			return nil, false
+		}
+		member := parseIdentifier(p)
+		return &ast.ScopeResolutionExpr{
+			Module:     module,
+			Identifier: member,
+			Location: ast.Location{
+				Start: module.StartPos(),
+				End:   member.EndPos(),
+			},
+		}, true
+	} else {
+		report.Add(p.filePath, p.peek().Start.Line, p.peek().End.Line, p.peek().Start.Column, p.peek().End.Column, "Left side of '::' must be an identifier").SetLevel(report.SYNTAX_ERROR)
+		return nil, false
 	}
 }

--- a/compiler/internal/parser/package.go
+++ b/compiler/internal/parser/package.go
@@ -1,0 +1,69 @@
+package parser
+
+import (
+	"ferret/compiler/internal/ast"
+	"ferret/compiler/internal/lexer"
+	"ferret/compiler/internal/symboltable"
+	"ferret/compiler/report"
+)
+
+// parsePackage parses a package declaration
+func parsePackage(p *Parser) ast.Node {
+	// Check if this is the first statement in the file
+
+	valid := p.tokenNo == 0
+
+	start := p.consume(lexer.PACKAGE_TOKEN, report.EXPECTED_PACKAGE_KEYWORD)
+
+	name := p.consume(lexer.IDENTIFIER_TOKEN, report.EXPECTED_PACKAGE_NAME)
+
+	if !valid {
+		report.Add(p.filePath, start.Start.Line, name.End.Line, start.Start.Column, name.End.Column, report.INVALID_SCOPE).AddHint("Package declarations must be at the top level of the file").SetLevel(report.SYNTAX_ERROR)
+	}
+
+	// check scope
+	if p.currentScope.ScopeKind() != symboltable.GLOBAL_SCOPE {
+		report.Add(p.filePath, name.Start.Line, name.End.Line, name.Start.Column, name.End.Column, report.INVALID_SCOPE).AddHint("Package declarations must be at the top level of the file").SetLevel(report.SYNTAX_ERROR)
+	}
+
+	return &ast.PackageDeclStmt{
+		Package: &ast.IdentifierExpr{
+			Name: name.Value,
+			Location: ast.Location{
+				Start: &name.Start,
+				End:   &name.End,
+			},
+		},
+		Location: ast.Location{
+			Start: &start.Start,
+			End:   &name.End,
+		},
+	}
+}
+
+// parseImport parses an import statement
+func parseImport(p *Parser) ast.Node {
+
+	start := p.consume(lexer.IMPORT_TOKEN, report.EXPECTED_IMPORT_KEYWORD)
+
+	importPath := p.consume(lexer.STRING_TOKEN, report.EXPECTED_IMPORT_PATH)
+
+	// check scope
+	if p.currentScope.ScopeKind() != symboltable.GLOBAL_SCOPE {
+		report.Add(p.filePath, start.Start.Line, importPath.End.Line, start.Start.Column, importPath.End.Column, report.INVALID_SCOPE).AddHint("Import statements must be at the top level of the file").SetLevel(report.SYNTAX_ERROR)
+	}
+
+	return &ast.ImportStmt{
+		Import: &ast.StringLiteral{
+			Value: importPath.Value,
+			Location: ast.Location{
+				Start: &importPath.Start,
+				End:   &importPath.End,
+			},
+		},
+		Location: ast.Location{
+			Start: &start.Start,
+			End:   &importPath.End,
+		},
+	}
+}

--- a/compiler/internal/parser/parser.go
+++ b/compiler/internal/parser/parser.go
@@ -11,7 +11,7 @@ import (
 
 type Parser struct {
 	tokens       []lexer.Token
-	current      int
+	tokenNo      int
 	filePath     string
 	symbolTable  *symboltable.SymbolTable
 	currentScope *symboltable.SymbolTable
@@ -22,7 +22,7 @@ func New(filePath string, debug bool) *Parser {
 	globalScope := symboltable.NewSymbolTable(nil, symboltable.GLOBAL_SCOPE)
 	return &Parser{
 		tokens:       tokens,
-		current:      0,
+		tokenNo:      0,
 		filePath:     filePath,
 		symbolTable:  globalScope,
 		currentScope: globalScope,
@@ -42,20 +42,20 @@ func (p *Parser) exitScope() {
 
 // current token
 func (p *Parser) peek() lexer.Token {
-	return p.tokens[p.current]
+	return p.tokens[p.tokenNo]
 }
 
 // previous token
 func (p *Parser) previous() lexer.Token {
-	return p.tokens[p.current-1]
+	return p.tokens[p.tokenNo-1]
 }
 
 // next returns the next token without consuming it
 func (p *Parser) next() lexer.Token {
-	if p.current+1 >= len(p.tokens) {
+	if p.tokenNo+1 >= len(p.tokens) {
 		return lexer.Token{Kind: lexer.EOF_TOKEN}
 	}
-	return p.tokens[p.current+1]
+	return p.tokens[p.tokenNo+1]
 }
 
 // is at end of file
@@ -66,7 +66,7 @@ func (p *Parser) isAtEnd() bool {
 // consume the current token and return that token
 func (p *Parser) advance() lexer.Token {
 	if !p.isAtEnd() {
-		p.current++
+		p.tokenNo++
 	}
 	return p.previous()
 }
@@ -208,6 +208,10 @@ func parseReturnStmt(p *Parser) ast.Statement {
 func parseNode(p *Parser) ast.Node {
 	var node ast.Node
 	switch p.peek().Kind {
+	case lexer.PACKAGE_TOKEN:
+		node = parsePackage(p)
+	case lexer.IMPORT_TOKEN:
+		node = parseImport(p)
 	case lexer.LET_TOKEN, lexer.CONST_TOKEN:
 		node = parseVarDecl(p)
 	case lexer.TYPE_TOKEN:

--- a/compiler/internal/parser/structs.go
+++ b/compiler/internal/parser/structs.go
@@ -64,7 +64,7 @@ func parseStructFields(p *Parser) ([]ast.StructField, bool) {
 		if p.match(lexer.CLOSE_CURLY) {
 			break
 		} else {
-			comma := p.consume(lexer.COMMA_TOKEN, report.EXPECTED_COMMA_OR_CLOSE_BRACE)
+			comma := p.consume(lexer.COMMA_TOKEN, report.EXPECTED_COMMA_OR_CLOSE_CURLY)
 			if p.match(lexer.CLOSE_CURLY) {
 				report.Add(p.filePath, comma.Start.Line, comma.End.Line, comma.Start.Column, comma.End.Column, report.TRAILING_COMMA_NOT_ALLOWED).AddHint("Remove the trailing comma").SetLevel(report.WARNING)
 				break
@@ -113,7 +113,7 @@ func parseStructLiteral(p *Parser) ast.Expression {
 }
 
 // parseFieldAccess parses a field access expression like struct.field
-func parseFieldAccess(p *Parser, object ast.Expression) ast.Expression {
+func parseFieldAccess(p *Parser, object ast.Expression) (ast.Expression, bool) {
 	p.advance() // consume '.'
 
 	// Parse field name
@@ -121,7 +121,7 @@ func parseFieldAccess(p *Parser, object ast.Expression) ast.Expression {
 		report.Add(p.filePath, p.peek().Start.Line, p.peek().End.Line,
 			p.peek().Start.Column, p.peek().End.Column,
 			"Expected field name after '.'").SetLevel(report.SYNTAX_ERROR)
-		return nil
+		return nil, false
 	}
 
 	fieldToken := p.advance()
@@ -140,5 +140,5 @@ func parseFieldAccess(p *Parser, object ast.Expression) ast.Expression {
 			Start: object.StartPos(),
 			End:   &fieldToken.End,
 		},
-	}
+	}, true
 }

--- a/compiler/internal/parser/typeParser.go
+++ b/compiler/internal/parser/typeParser.go
@@ -221,7 +221,7 @@ func parseStructType(p *Parser) (ast.DataType, bool) {
 		if p.match(lexer.CLOSE_CURLY) {
 			break
 		} else {
-			comma := p.consume(lexer.COMMA_TOKEN, report.EXPECTED_COMMA_OR_CLOSE_BRACE)
+			comma := p.consume(lexer.COMMA_TOKEN, report.EXPECTED_COMMA_OR_CLOSE_CURLY)
 			if p.match(lexer.CLOSE_CURLY) {
 				report.Add(p.filePath, comma.Start.Line, comma.End.Line, comma.Start.Column, comma.End.Column, report.TRAILING_COMMA_NOT_ALLOWED).AddHint("Remove the trailing comma").SetLevel(report.WARNING)
 				break
@@ -289,7 +289,7 @@ func parseInterfaceType(p *Parser) (ast.DataType, bool) {
 			break
 		} else {
 			//must be a comma
-			comma := p.consume(lexer.COMMA_TOKEN, report.EXPECTED_COMMA_OR_CLOSE_BRACE)
+			comma := p.consume(lexer.COMMA_TOKEN, report.EXPECTED_COMMA_OR_CLOSE_CURLY)
 			if p.match(lexer.CLOSE_CURLY) {
 				report.Add(p.filePath, comma.Start.Line, comma.End.Line, comma.Start.Column, comma.End.Column, report.TRAILING_COMMA_NOT_ALLOWED).AddHint("Remove the trailing comma").SetLevel(report.WARNING)
 				break

--- a/compiler/internal/symboltable/table.go
+++ b/compiler/internal/symboltable/table.go
@@ -26,6 +26,7 @@ const (
 	STRUCT_FIELD_SYMBOL
 	PARAMETER_SYMBOL
 	CONST_SYMBOL
+	MODULE_SYMBOL
 )
 
 var compilerGlobalSymbols = map[string]*Symbol{
@@ -55,6 +56,7 @@ type Symbol struct {
 	IsMutable  bool            // Whether the symbol can be modified
 	Location   SymbolLocation  // Source location information
 	Value      any             // For constants and compile-time known values
+	Module     string          // The module this symbol belongs to (if any)
 }
 
 // SymbolLocation tracks the source location of a symbol
@@ -169,4 +171,21 @@ func (st *SymbolTable) ExitScope() *SymbolTable {
 		return st // Can't exit global scope
 	}
 	return st.parent
+}
+
+// ResolveInModule looks up a symbol by name in a specific module
+func (st *SymbolTable) ResolveInModule(module, name string) (*Symbol, bool) {
+	// Check current scope
+	for _, sym := range st.symbols {
+		if sym.Module == module && sym.Name == name && sym.IsExported {
+			return sym, true
+		}
+	}
+
+	// Check parent scopes
+	if st.parent != nil {
+		return st.parent.ResolveInModule(module, name)
+	}
+
+	return nil, false
 }

--- a/compiler/internal/types/builtins.go
+++ b/compiler/internal/types/builtins.go
@@ -21,4 +21,5 @@ const (
 	INTERFACE TYPE_NAME = "interface"
 	VOID      TYPE_NAME = "void"
 	STRUCT    TYPE_NAME = "struct"
+	MODULE    TYPE_NAME = "module"
 )

--- a/compiler/main.go
+++ b/compiler/main.go
@@ -7,9 +7,9 @@ import (
 
 func main() {
 
-	filename := "./../code/start.fer"
+	filename := "./../code/main.fer"
 
-	r, err := analyzer.Analyze(filename, true, false, true)
+	r, err := analyzer.Analyze(filename, true, true, true)
 
 	if len(r) > 0 {
 		r.DisplayAll()

--- a/compiler/report/constants.go
+++ b/compiler/report/constants.go
@@ -137,13 +137,14 @@ const (
 	EXPECTED_CLOSE_PAREN            = "Expected ')'"
 	EXPECTED_COMMA_OR_CLOSE_PAREN   = "Expected ',' or ')'"
 	EXPECTED_COMMA_OR_CLOSE_BRACKET = "Expected ',' or ']'"
-	EXPECTED_COMMA_OR_CLOSE_BRACE   = "Expected ',' or '}'"
+	EXPECTED_COMMA_OR_CLOSE_CURLY   = "Expected ',' or '}'"
 )
 
 // scope errors
 const (
-	SCOPE_MISMATCH = "Scope mismatch"
-	INVALID_SCOPE  = "Invalid scope"
+	SCOPE_MISMATCH                     = "Scope mismatch"
+	INVALID_SCOPE                      = "Invalid scope"
+	EXPECTED_SCOPE_RESOLUTION_OPERATOR = "Expected '::' operator"
 )
 
 // Statement errors

--- a/compiler/report/constants.go
+++ b/compiler/report/constants.go
@@ -1,5 +1,14 @@
 package report
 
+// package error messages
+const (
+	EXPECTED_PACKAGE_KEYWORD = "Expected 'package' keyword"
+	EXPECTED_IMPORT_KEYWORD  = "Expected 'import' keyword"
+	EXPECTED_PACKAGE_NAME    = "Expected package name"
+	EXPECTED_IMPORT_PATH     = "Expected import path"
+	INVALID_IMPORT_PATH      = "Invalid import path"
+)
+
 // general error messages
 const (
 	MISSING_NAME      = "Expected variable name"
@@ -24,7 +33,7 @@ const (
 const (
 	EXPECTED_NUMBER      = "Expected number"
 	EXPECTED_STRING      = "Expected string"
-	EXPECTED_SEMI_COLON  = "Expected ';'"
+	EXPECTED_SEMICOLON   = "Expected ';'"
 	EXPECTED_COMMA       = "Expected ','"
 	EXPECTED_COLON       = "Expected ':'"
 	EXPECTED_EQUALS      = "Expected '='"
@@ -134,6 +143,7 @@ const (
 // scope errors
 const (
 	SCOPE_MISMATCH = "Scope mismatch"
+	INVALID_SCOPE  = "Invalid scope"
 )
 
 // Statement errors

--- a/readme.md
+++ b/readme.md
@@ -142,6 +142,10 @@ type Matrix [][]f32;
 - [ ] Range expressions
 - [ ] Error handling
 - [ ] Imports and modules
+    - [x] Import statements
+    - [x] Scope resolution
+    - [x] Module declarations
+    - [ ] Parsing of imported modules
 - [ ] Nullable/optional types
 - [ ] Generics
 - [ ] Advanced code generation


### PR DESCRIPTION
This pull request introduces several significant changes to the Ferret language compiler, including the addition of package and import statement support, the implementation of scope resolution expressions, and improvements to the parser to handle trailing commas in various contexts. 

### Support for Package and Import Statements:
* Added `PackageDeclStmt` and `ImportStmt` structures to represent package declarations and import statements in the AST (`compiler/internal/ast/stmt.go`).
* Introduced `parsePackage` and `parseImport` functions to handle package and import statements (`compiler/internal/parser/package.go`).
* Added `PACKAGE_TOKEN` and `IMPORT_TOKEN` to the lexer tokens (`compiler/internal/lexer/tokens.go`). [[1]](diffhunk://#diff-1171898efdd777376dd7995fd8b9b796baaff84e8eaf217a965833ea8f583465R26-R27) [[2]](diffhunk://#diff-1171898efdd777376dd7995fd8b9b796baaff84e8eaf217a965833ea8f583465R107-R108)

### Implementation of Scope Resolution Expressions:
* Added `ScopeResolutionExpr` structure to represent scope resolution expressions in the AST (`compiler/internal/ast/expr.go`).
* Introduced `parseScopeResolution` function to handle scope resolution expressions (`compiler/internal/parser/package.go`).
* Added `SCOPE_TOKEN` to the lexer tokens and updated the tokenizer to recognize the scope resolution operator (`compiler/internal/lexer/tokens.go`, `compiler/internal/lexer/tokenizer.go`). [[1]](diffhunk://#diff-117a2d630578bd7673f8b88e5a088ef4b22c53d43c989f6ce9a01fa3c4a266b2R75) [[2]](diffhunk://#diff-1171898efdd777376dd7995fd8b9b796baaff84e8eaf217a965833ea8f583465R65)

### Parser Improvements:
* Modified `parseFunctionCall`, `parseIndexing`, and `parseIncDec` functions to handle trailing commas and return a boolean indicating success (`compiler/internal/parser/expr.go`). [[1]](diffhunk://#diff-d548106f7db31b68523ed7375e0eed329d506bcfddcc764e72fb83ad51f6652fL247-R263) [[2]](diffhunk://#diff-d548106f7db31b68523ed7375e0eed329d506bcfddcc764e72fb83ad51f6652fL295-R335)
* Updated `parseReturnTypes` to handle single return types more effectively (`compiler/internal/parser/function.go`). [[1]](diffhunk://#diff-bd46289920c70af3b234209a9988779af85c43bc8fe6a45ed642947135501375L132-R142) [[2]](diffhunk://#diff-bd46289920c70af3b234209a9988779af85c43bc8fe6a45ed642947135501375L148-L167)
* Enhanced `parseArrayLiteral` to handle trailing commas (`compiler/internal/parser/literals.go`).

### Example Code and AST Representation:
* Added an example Ferret program with a package, import, and main function (`code/main.fer`).
* Updated the AST representation for the example program (`code/ast/main.fer.json`).