### PR TITLE
Refactor

### DIFF
--- a/compiler/internal/parser/package.go
+++ b/compiler/internal/parser/package.go
@@ -64,7 +64,6 @@ func parseImport(p *Parser) ast.Node {
 		Name:       moduleName,
 		SymbolKind: symboltable.MODULE_SYMBOL,
 		Type:       types.MODULE,
-		IsExported: true,
 		Module:     moduleName,
 		Location: symboltable.SymbolLocation{
 			File:   p.filePath,

--- a/compiler/internal/symboltable/table.go
+++ b/compiler/internal/symboltable/table.go
@@ -2,6 +2,7 @@ package symboltable
 
 import (
 	"ferret/compiler/internal/types"
+	"ferret/compiler/internal/utils"
 )
 
 type ScopeKind int
@@ -52,7 +53,6 @@ type Symbol struct {
 	SymbolKind SYMBOL_KIND     // The kind of symbol (variable, function, etc.)
 	Type       types.TYPE_NAME // The type of the symbol
 	Scope      ScopeKind       // The scope in which this symbol is defined
-	IsExported bool            // Whether the symbol is exported (public)
 	IsMutable  bool            // Whether the symbol can be modified
 	Location   SymbolLocation  // Source location information
 	Value      any             // For constants and compile-time known values
@@ -177,7 +177,7 @@ func (st *SymbolTable) ExitScope() *SymbolTable {
 func (st *SymbolTable) ResolveInModule(module, name string) (*Symbol, bool) {
 	// Check current scope
 	for _, sym := range st.symbols {
-		if sym.Module == module && sym.Name == name && sym.IsExported {
+		if sym.Module == module && sym.Name == name && utils.IsCapitalized(sym.Name) {
 			return sym, true
 		}
 	}

--- a/compiler/internal/symboltable/table_test.go
+++ b/compiler/internal/symboltable/table_test.go
@@ -2,6 +2,7 @@ package symboltable
 
 import (
 	"ferret/compiler/internal/types"
+	"ferret/compiler/internal/utils"
 	"testing"
 )
 
@@ -336,7 +337,6 @@ func TestModuleScope(t *testing.T) {
 				Name:       tt.name,
 				SymbolKind: VARIABLE_SYMBOL,
 				Type:       types.INT32,
-				IsExported: tt.isExported,
 			}
 			if !module.Define(sym) {
 				t.Errorf("Failed to define symbol %s", tt.name)
@@ -346,8 +346,9 @@ func TestModuleScope(t *testing.T) {
 			if !found {
 				t.Errorf("Failed to resolve symbol %s", tt.name)
 			}
-			if resolved.IsExported != tt.isExported {
-				t.Errorf("Wrong export status for %s: got %v, want %v", tt.name, resolved.IsExported, tt.isExported)
+
+			if utils.IsCapitalized(resolved.Name) != tt.isExported {
+				t.Errorf("Wrong export status for %s: got %v, want %v", tt.name, utils.IsCapitalized(resolved.Name), tt.isExported)
 			}
 		}
 	})


### PR DESCRIPTION
This pull request includes several changes to the `symboltable` package and related files to remove the `IsExported` field from the `Symbol` struct and replace it with a utility function to determine if a symbol is exported based on its name capitalization. The most important changes include updating the `Symbol` struct, modifying the `ResolveInModule` method, and adjusting the corresponding tests.

Changes to `symboltable` package:

* [`compiler/internal/symboltable/table.go`](diffhunk://#diff-ccd35748ed9c1bfc11e377c1fbbef36fb19b557c49fd719724c54d3fcfacc9fbL55): Removed the `IsExported` field from the `Symbol` struct and replaced its usage with the `utils.IsCapitalized` function in the `ResolveInModule` method. [[1]](diffhunk://#diff-ccd35748ed9c1bfc11e377c1fbbef36fb19b557c49fd719724c54d3fcfacc9fbL55) [[2]](diffhunk://#diff-ccd35748ed9c1bfc11e377c1fbbef36fb19b557c49fd719724c54d3fcfacc9fbL180-R180)
* [`compiler/internal/symboltable/table.go`](diffhunk://#diff-ccd35748ed9c1bfc11e377c1fbbef36fb19b557c49fd719724c54d3fcfacc9fbR5): Added an import for the `utils` package.

Changes to tests:

* [`compiler/internal/symboltable/table_test.go`](diffhunk://#diff-c44de7524f5b9c65a0d598a0c870105d0dc057465f816d402ddbabb357910166L339): Updated the `TestModuleScope` test to use the `utils.IsCapitalized` function instead of checking the `IsExported` field directly. [[1]](diffhunk://#diff-c44de7524f5b9c65a0d598a0c870105d0dc057465f816d402ddbabb357910166L339) [[2]](diffhunk://#diff-c44de7524f5b9c65a0d598a0c870105d0dc057465f816d402ddbabb357910166L349-R351)
* [`compiler/internal/symboltable/table_test.go`](diffhunk://#diff-c44de7524f5b9c65a0d598a0c870105d0dc057465f816d402ddbabb357910166R5): Added an import for the `utils` package.

Change to parser:

* [`compiler/internal/parser/package.go`](diffhunk://#diff-d0730cd38eeece316b1f94127e38ff0503b3e8dc372a1246d6a906a2da8483cdL67): Removed the `IsExported` field assignment in the `parseImport` function.